### PR TITLE
JWTUtil and AuthAspectchanges

### DIFF
--- a/src/main/java/com/revature/advice/AuthAspect.java
+++ b/src/main/java/com/revature/advice/AuthAspect.java
@@ -47,11 +47,12 @@ public class AuthAspect {
     @Around("@annotation(authorized)")
     public Object authenticate(ProceedingJoinPoint pjp, Authorized authorized) throws Throwable {
         try {
-            String[] token = req.getHeader("Authorization").split(" ");
+            String t = req.getHeader("Authorization");
+            String[] token = t.split(" ");
             if(!token[0].equals("Bearer")) {
                 throw new Exception();
             }
-            JWTUtil.verifyUserToken(token[1]);
+            JWTUtil.verifyUserToken(t);
             return pjp.proceed(pjp.getArgs()); // Call the originally intended method
         } catch (Exception e) {
             throw new NotLoggedInException("Must be logged in to perform this action");

--- a/src/main/java/com/revature/utils/JWTUtil.java
+++ b/src/main/java/com/revature/utils/JWTUtil.java
@@ -33,11 +33,15 @@ public class JWTUtil {
     }
 
     // taken from io.jsonwebtoken documentation 
-    public static String verifyUserToken(String token) {
+    public static int verifyUserToken(String authToken) {
+        String token = authToken.split(" ")[1];
+
         Jws<Claims> jws = Jwts.parserBuilder()
             .setSigningKey(key)
             .build()        
             .parseClaimsJws(token);
-        return jws.getBody().get("sub").toString();
+
+        return Integer.parseInt(jws.getBody().get("sub").toString());
     }
+
 }


### PR DESCRIPTION
- Changed return type value of JWTUtil from string to int (user id)
- JWTUtil now takes in the entire token (including "Bearer" part) instead of only the second encrypted part
- Modified AuthAspect accordingly